### PR TITLE
Conditional cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ end
 The middleware currently takes several options:
 
   * `conditions`: Conditional caching (default GET and HEAD requests).
+  * `cache_key`: Key for requests comparison (default URL)
   * `expires_in`: Cache expiry, in seconds (default 30).
   * `logger`: Specify a logger to enable logging.
 
@@ -54,7 +55,11 @@ require 'faraday'
 require 'faraday-manual-cache'
 
 connection = Faraday.new(url: 'http://example.com') do |builder|
-  builder.use :manual_cache, conditions: ->(env) { env.method == :get }, expires_in: 10, logger: Rails.logger
+  builder.use :manual_cache,
+              conditions: ->(env) { env.method == :get },
+              cache_key: ->(env) { "prefix-#{env.url}" },
+              expires_in: 10,
+              logger: Rails.logger
   builder.adapter Faraday.default_adapter
 end
 ```

--- a/lib/faraday/manual_cache.rb
+++ b/lib/faraday/manual_cache.rb
@@ -16,6 +16,7 @@ module Faraday
 
   class ManualCache < Faraday::Middleware
     DEFAULT_CONDITIONS = ->(env) { env.method == :get || env.method == :head }
+    DEFAULT_KEY = ->(env) { env.url }
 
     def initialize(app, *args)
       super(app)
@@ -23,6 +24,7 @@ module Faraday
       @conditions    = options.fetch(:conditions, DEFAULT_CONDITIONS)
       @expires_in    = options.fetch(:expires_in, 30)
       @logger        = options.fetch(:logger, nil)
+      @cache_key     = options.fetch(:cache_key, DEFAULT_KEY)
     end
 
     def call(env)
@@ -75,7 +77,7 @@ module Faraday
     end
 
     def key(env)
-      env.url
+      @cache_key.call(env)
     end
 
     def store

--- a/lib/faraday/manual_cache.rb
+++ b/lib/faraday/manual_cache.rb
@@ -16,7 +16,7 @@ module Faraday
 
   class ManualCache < Faraday::Middleware
     DEFAULT_CONDITIONS = ->(env) { env.method == :get || env.method == :head }
-    DEFAULT_KEY = ->(env) { env.url }
+    DEFAULT_CACHE_KEY = ->(env) { env.url }
 
     def initialize(app, *args)
       super(app)
@@ -24,7 +24,7 @@ module Faraday
       @conditions    = options.fetch(:conditions, DEFAULT_CONDITIONS)
       @expires_in    = options.fetch(:expires_in, 30)
       @logger        = options.fetch(:logger, nil)
-      @cache_key     = options.fetch(:cache_key, DEFAULT_KEY)
+      @cache_key     = options.fetch(:cache_key, DEFAULT_CACHE_KEY)
     end
 
     def call(env)

--- a/spec/manual_cache_spec.rb
+++ b/spec/manual_cache_spec.rb
@@ -88,4 +88,21 @@ RSpec.describe Faraday::ManualCache do
       subject.put('/')
     end
   end
+
+  context 'conditional configuration with cache key' do
+    subject do
+      Faraday.new(url: 'http://www.example.com') do |faraday|
+        faraday.use :manual_cache,
+                    conditions: ->(_) { true },
+                    cache_key: ->(env) { "prefix-#{env.url}" }
+        faraday.adapter :test, stubs
+      end
+    end
+
+    it 'should cache based of cache_key' do
+      expect(store).to receive(:fetch)
+      expect(store).to receive(:write).with('prefix-http://www.example.com/', any_args)
+      subject.get('/')
+    end
+  end
 end


### PR DESCRIPTION
Adds ability to control cache key. Just URL can be insufficient in some cases . With this feature it can be defined based on what requests will be cached: request_headers, parameters etc.
