### PR TITLE
Allow expires in to be set dynamically

### DIFF
--- a/lib/faraday/manual_cache.rb
+++ b/lib/faraday/manual_cache.rb
@@ -51,7 +51,11 @@ module Faraday
       return unless cacheable?(env) && !env.request_headers['x-faraday-manual-cache']
 
       info "Cache WRITE: #{key(env)}"
-      store.write(key(env), env, expires_in: @expires_in)
+      store.write(
+        key(env),
+        env,
+        expires_in: expires_in(env)
+      )
     end
 
     def cacheable?(env)
@@ -78,6 +82,10 @@ module Faraday
 
     def key(env)
       @cache_key.call(env)
+    end
+
+    def expires_in(env)
+      @expires_in.respond_to?(:call) ? @expires_in.call(env) : @expires_in
     end
 
     def store


### PR DESCRIPTION
Hey @dobs,

Thanks for this repo, we use it at my company quite extensively. One issue we're running into is the cache entries expiring all at once due to the entries being warmed all at once. This causes spikes in traffic that we'd like to smooth out.

Our goal is to introduce a bit of noise to the entries we are caching to allow for re-fetching to be smoothed out.

Example:

```ruby
faraday.use :manual_cache,
            expires_in: ->(_) { 86400 +  rand(0..1440) }
```

Let me know if you'd like me to make any changes. Thanks.