### PR TITLE
Bump faraday version

### DIFF
--- a/faraday-manual-cache.gemspec
+++ b/faraday-manual-cache.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 1.9'
 
   spec.add_dependency 'activesupport', '>= 3.0.0'
-  spec.add_dependency 'faraday', '>= 0.9'
+  spec.add_dependency 'faraday', '>= 1.3'
 
   spec.add_development_dependency 'bundler', '>= 1.5'
   spec.add_development_dependency 'rake'

--- a/lib/faraday-manual-cache/version.rb
+++ b/lib/faraday-manual-cache/version.rb
@@ -1,3 +1,3 @@
 module FaradayManualCache
-  VERSION = '0.4.0'.freeze
+  VERSION = '0.5.0'.freeze
 end


### PR DESCRIPTION
The gem is slowly being outdated. This should enable it to be used with the latest versions of Faraday.